### PR TITLE
Add numpy

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -13,7 +13,7 @@ setuptools.setup(
     long_description_content_type="text/markdown",
     url="https://github.com/LonePurpleWolf/airtouch4pyapi",
     packages=setuptools.find_packages(),
-    install_requires=[''],
+    install_requires=['numpy'],
     classifiers=[
         "Programming Language :: Python :: 3",
         "License :: OSI Approved :: MIT License",


### PR DESCRIPTION
`numpy` is a [requirement](https://github.com/LonePurpleWolf/airtouch4pyapi/blob/main/airtouch4pyapi/communicate.py#L75).